### PR TITLE
Addin VTF output in the time step loop

### DIFF
--- a/NelderMead.h
+++ b/NelderMead.h
@@ -1,7 +1,4 @@
 #include <algorithm>
-#include <array>
-#include <map>
-#include <numeric>
 #include <vector>
 
 template<class Key, class Value>
@@ -13,16 +10,16 @@ struct NelderMead
   };
 
   template<class Function, class Convergence>
-  static Key optimize(std::vector<Entry>& vectors, Value& result, int dim, double tol,
-                      Function&& f, Convergence&& conv)
+  static Entry optimize(std::vector<Entry>& vectors, Function&& f, Convergence&& conv)
   {
-    bool done = conv(vectors[0].val) < tol;
-
-    while (!done) {
-      std::sort(vectors.begin(), vectors.end(), [f](const Entry& a, const Entry& b)
+    Entry best = vectors.front();
+    while (!conv(best.val)) {
+      std::sort(vectors.begin(), vectors.end(), [](const Entry& a, const Entry& b)
                                                 {
                                                   return a.val < b.val;
                                                 });
+      best = vectors.front();
+
       Key cog(vectors[0].key);
       cog.fill(0.0);
       for (size_t i = 0; i < vectors.size()-1; ++i)
@@ -30,7 +27,6 @@ struct NelderMead
 
       cog /= vectors.size()-1;
 
-      auto best = vectors.front();
       auto worst = vectors.back();
       auto second_worst = vectors[vectors.size()-2];
 
@@ -73,11 +69,8 @@ struct NelderMead
           }
         }
       }
-      done = conv(fb) < tol;
-      if (done)
-        result = fb;
     }
 
-    return vectors[0].key;
+    return vectors.front();
   } 
 };

--- a/inner_optimize/instance.xinp
+++ b/inner_optimize/instance.xinp
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
-<!-- Thick cylinder.
-     Static linear-elastic analysis, quartic spline elements. -->
+<!-- Digital twin model of two metal rods in a rectangular support box. -->
 
 <simulation>
 
@@ -53,8 +52,10 @@
 
   <postprocessing>
     <vtfformat>BINARY</vtfformat>
-    <resultpoints>
-      <point patch="31" u="0.5" v="0.0" w="0.37864"/>
+    <resultpoints vtfsize="0.005">
+      <point patch="1"  u="0.0" v="0.5" w="0.2582524"/>
+      <point patch="1"  u="0.5" v="1.0" w="0.2582524"/>
+      <point patch="37" u="0.5" v="1.0" w="0.0"/>
     </resultpoints>
   </postprocessing>
 

--- a/main_DiTwi.C
+++ b/main_DiTwi.C
@@ -50,7 +50,7 @@ public:
     for (ASMbase* pch : SIM3D::myModel)
       this->evalResults(psol,SIM3D::myPoints.front().second,
                         pch,points,Xp,sol1,sol2);
-    return sol2(6,1);
+    return sol2(3,1); // eps_zz in result point 1
   }
 };
 
@@ -65,7 +65,7 @@ public:
   //! \brief The constructor forwards to the parent class constructor.
   explicit DigTwinDriver(SIMDigitalTwin& sim) : ModalDriver(sim), myModel(sim)
   {
-    myTarget = 0.0;
+    myTarget = 1.0e-4; // Default target strain
     m_solve = m_advance = m_done = false;
     iStep = 0;
   }
@@ -158,9 +158,16 @@ public:
           IFEM::cout << "--- end of iteration ---" << std::endl;
         }
 
-        m_solve = false;
-
-        IFEM::pollControllerFifo();
+        if (IFEM::pollControllerFifo())
+          m_solve = false;
+        else if (!m_solve)
+          m_solve = true;
+        else
+        {
+          // Dry-run without external control, just continue
+          m_advance = true;
+          m_solve = false;
+        }
 
 //        if (!m_advance) {
 //          this->solution = backupSol;


### PR DESCRIPTION
I think this (second commit) is what's needed to get VTF output of the DT-simulation.
The first commit  with some additional cleaning which I hope not will affect behavior.
Requires the latest updates from OPM/IFEM#379 and OPM/IFEM-Elasticity#94.

NOT TESTED!! Since I did not have a test case at hand.